### PR TITLE
implement get_queryables call

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -66,7 +66,7 @@ class FilterExtension(ApiExtension):
     POST = FilterExtensionPostRequest
 
     client: Union[AsyncBaseFiltersClient, BaseFiltersClient] = attr.ib(
-        factory=BaseFiltersClient
+        factory=AsyncBaseFiltersClient
     )
     conformance_classes: List[str] = attr.ib(
         default=[

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     "brotli_asgi",
     "pygeofilter>=0.1,<0.2",
     "pypgstac==0.6.*",
+    "pygeoif==0.7"
 ]
 
 extra_reqs = {

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -17,6 +17,7 @@ from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.search import BaseSearchPostRequest
 from stac_fastapi.types.stac import Conformance
+from stac_fastapi.pgstac.db import dbfunc
 
 NumType = Union[float, int]
 StacType = Dict[str, Any]
@@ -717,8 +718,9 @@ class AsyncBaseFiltersClient(abc.ABC):
         under OGC CQL but it is allowed by the STAC API Filter Extension
 
         https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter#queryables
-        """
-        return {
+
+        Example return structure:
+        {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "https://example.org/queryables",
             "type": "object",
@@ -726,6 +728,10 @@ class AsyncBaseFiltersClient(abc.ABC):
             "description": "Queryable names for the example STAC API Item Search filter.",
             "properties": {},
         }
+        """
+        request = kwargs["request"]
+        pool = request.app.state.writepool
+        return await dbfunc(pool, "get_queryables", collection_id if collection_id else 'null')
 
 
 @attr.s


### PR DESCRIPTION
This leverages the `get_queryables` sql function included in pgstac v0.6.8

Also addresses bug with new version of `pygeoif`, locking it to last working version. See https://github.com/stac-utils/stac-fastapi/pull/466 
